### PR TITLE
Update the bridge URL in the sample code

### DIFF
--- a/ExampleApps/ClientApp/WalletConnect.swift
+++ b/ExampleApps/ClientApp/WalletConnect.swift
@@ -23,10 +23,10 @@ class WalletConnect {
     }
 
     func connect() -> String {
-        // gnosis wc bridge: https://safe-walletconnect.gnosis.io/
+        // gnosis wc bridge: https://safe-walletconnect.safe.global/
         // test bridge with latest protocol version: https://bridge.walletconnect.org
         let wcUrl =  WCURL(topic: UUID().uuidString,
-                           bridgeURL: URL(string: "https://safe-walletconnect.gnosis.io/")!,
+                           bridgeURL: URL(string: "https://safe-walletconnect.safe.global/")!,
                            key: try! randomKey())
         let clientMeta = Session.ClientMeta(name: "ExampleDApp",
                                             description: "WalletConnectSwift",


### PR DESCRIPTION
Update the bridge URL in the sample code from:

`https://safe-walletconnect.gnosis.io/`

To:

`https://safe-walletconnect.safe.global/`

According to the discussions here:

https://github.com/WalletConnect/WalletConnectSwift/issues/137

Without this update, the QR code generated by the sample code would only work with Trust Wallet but not with MetaMask or Rainbow because it seems only Trust handled a redirection in the bridge.